### PR TITLE
Balancing

### DIFF
--- a/mods/radiv/mod.yaml
+++ b/mods/radiv/mod.yaml
@@ -67,6 +67,7 @@ Rules:
     radiv|rules/civilian.yaml
     radiv|rules/defaults.yaml
     radiv|rules/misc.yaml
+    radiv|rules/player.yaml
 
 Sequences:
 	ra|sequences/ships.yaml

--- a/mods/radiv/rules/aircraft.yaml
+++ b/mods/radiv/rules/aircraft.yaml
@@ -102,7 +102,7 @@ Bomber:
 		Offset: -432,-560,0
 		Interval: 2
 	AmmoPool:
-		Ammo: 5
+		Ammo: 10
         AmmoCondition: ammo
 	Armament:
 		Weapon: BadrBomb
@@ -313,7 +313,7 @@ FireBomber:
 		InitialStance: HoldFire
 		InitialStanceAI: HoldFire
 	AmmoPool:
-		Ammo: 100
+		Ammo: 200
 		ReloadDelay: 5
 		AmmoCondition: ammo
 	WithMuzzleOverlay:

--- a/mods/radiv/rules/civilian.yaml
+++ b/mods/radiv/rules/civilian.yaml
@@ -13,6 +13,7 @@ MoneyHolder:
     DamageMultiplier:
         Modifier: 0
     -Targetable:
+    -Crushable:
     StoresResources: 
         Capacity: 50000
     CashTrickler@Decrease:

--- a/mods/radiv/rules/defaults.yaml
+++ b/mods/radiv/rules/defaults.yaml
@@ -233,34 +233,34 @@
 		Modifier: 75
 	DamageMultiplier@RANK-ELITE2:
 		RequiresCondition: rank-veteran == 5
-		Modifier: 65
+		Modifier: 60
 	DamageMultiplier@RANK-ELITE3:
 		RequiresCondition: rank-veteran == 6
-		Modifier: 50
+		Modifier: 45
 	DamageMultiplier@RANK-ELITE4:
 		RequiresCondition: rank-veteran >= 7
-		Modifier: 30
+		Modifier: 25
 	FirepowerMultiplier@RANK-1:
 		RequiresCondition: rank-veteran == 1
-		Modifier: 105
+		Modifier: 110
 	FirepowerMultiplier@RANK-2:
 		RequiresCondition: rank-veteran == 2
-		Modifier: 110
+		Modifier: 120
 	FirepowerMultiplier@RANK-3:
 		RequiresCondition: rank-veteran == 3
-		Modifier: 120
+		Modifier: 135
 	FirepowerMultiplier@RANK-ELITE:
 		RequiresCondition: rank-veteran == 4
-		Modifier: 130
+		Modifier: 150
 	FirepowerMultiplier@RANK-ELITE2:
 		RequiresCondition: rank-veteran == 5
-		Modifier: 140
+		Modifier: 165
 	FirepowerMultiplier@RANK-ELITE3:
 		RequiresCondition: rank-veteran == 6
-		Modifier: 155
+		Modifier: 180
 	FirepowerMultiplier@RANK-ELITE4:
 		RequiresCondition: rank-veteran >= 7
-		Modifier: 175
+		Modifier: 200
 	SpeedMultiplier@RANK-1:
 		RequiresCondition: rank-veteran == 1
 		Modifier: 105
@@ -306,16 +306,16 @@
 	ChangesHealth@ELITE:
 		Step: 0
 		PercentageStep: 5
-		Delay: 100
+		Delay: 30
 		StartIfBelow: 100
-		DamageCooldown: 125
+		DamageCooldown: 50
 		RequiresCondition: rank-elite
 	ChangesHealth@ELITE4:
 		Step: 0
 		PercentageStep: 10
-		Delay: 50
+		Delay: 15
 		StartIfBelow: 100
-		DamageCooldown: 50
+		DamageCooldown: 20
 		RequiresCondition: rank-elite4
 	WithDecoration@RANK-1:
 		Image: rank
@@ -619,17 +619,10 @@
 	TimedConditionBar@HQCHARGE:
 		Condition: hqcharge
     FirepowerMultiplier@HQCHARGE:
-        Modifier: 150
+        Modifier: 175
         RequiresCondition: hqcharge
     SpeedMultiplier@HQCHARGE:
-        Modifier: 150
-        RequiresCondition: hqcharge
-    ChangesHealth@HQCHARGE:
-        Step: 0
-        PercentageStep: -10
-        Delay: 100
-        StartIfBelow: 110
-        DamageTypes: DefaultDeath
+        Modifier: 175
         RequiresCondition: hqcharge
     ExternalCondition@HQRETREAT:
         Condition: hqretreat
@@ -639,7 +632,7 @@
         Modifier: 0
         RequiresCondition: hqretreat
     SpeedMultiplier@HQRETREAT:
-        Modifier: 200
+        Modifier: 250
         RequiresCondition: hqretreat
     ExternalCondition@HQSUICIDE:
         Condition: hqsuicide
@@ -658,7 +651,7 @@
         Modifier: 150
         RequiresCondition: hqsuicide
     KillsSelf@HQSUICIDE:
-        Delay: 250
+        Delay: 375
         DamageTypes: DefaultDeath
         RequiresCondition: hqsuicide
 
@@ -814,13 +807,6 @@
     SpeedMultiplier@HQCHARGE:
         Modifier: 150
         RequiresCondition: hqcharge
-    ChangesHealth@HQCHARGE:
-        Step: 0
-        PercentageStep: -10
-        Delay: 100
-        StartIfBelow: 110
-        DamageTypes: DefaultDeath
-        RequiresCondition: hqcharge
     ExternalCondition@HQRETREAT:
         Condition: hqretreat
 	TimedConditionBar@HQRETREAT:
@@ -829,17 +815,17 @@
         Modifier: 0
         RequiresCondition: hqretreat
     SpeedMultiplier@HQRETREAT:
-        Modifier: 200
+        Modifier: 250
         RequiresCondition: hqretreat
     ExternalCondition@HQENTRENCH:
         Condition: hqentrench
 	TimedConditionBar@HQENTRENCH:
 		Condition: hqentrench
     DamageMultiplier@HQENTRENCH:
-        Modifier: 50
+        Modifier: 30
         RequiresCondition: hqentrench
     SpeedMultiplier@HQENTRENCH:
-        Modifier: 5
+        Modifier: 50
         RequiresCondition: hqentrench
     ExternalCondition@HQSUICIDE:
         Condition: hqsuicide
@@ -858,7 +844,7 @@
         Modifier: 150
         RequiresCondition: hqsuicide
     KillsSelf@HQSUICIDE:
-        Delay: 250
+        Delay: 375
         DamageTypes: DefaultDeath
         RequiresCondition: hqsuicide
 
@@ -979,13 +965,6 @@
     SpeedMultiplier@HQCHARGE:
         Modifier: 150
         RequiresCondition: hqcharge
-    ChangesHealth@HQCHARGE:
-        Step: 0
-        PercentageStep: -10
-        Delay: 100
-        StartIfBelow: 110
-        DamageTypes: DefaultDeath
-        RequiresCondition: hqcharge
     ExternalCondition@HQRETREAT:
         Condition: hqretreat
 	TimedConditionBar@HQRETREAT:
@@ -994,7 +973,7 @@
         Modifier: 0
         RequiresCondition: hqretreat
     SpeedMultiplier@HQRETREAT:
-        Modifier: 200
+        Modifier: 250
         RequiresCondition: hqretreat
     ExternalCondition@HQSUICIDE:
         Condition: hqsuicide
@@ -1013,7 +992,7 @@
         Modifier: 150
         RequiresCondition: hqsuicide
     KillsSelf@HQSUICIDE:
-        Delay: 250
+        Delay: 375
         DamageTypes: DefaultDeath
         RequiresCondition: hqsuicide
 
@@ -1101,6 +1080,21 @@
     FirepowerMultiplier@AIRFORCE:
         Modifier: 80
         RequiresCondition: airforcemoney
+    GrantConditionOnPrerequisite@BETTERPLANES:
+        Condition: betterplanes
+        Prerequisites: betterplanes
+    ReloadAmmoDelayMultiplier@BETTERPLANES:
+        Modifier: 50
+        RequiresCondition: betterplanes
+    ProductionCostMultiplier@BETTERPLANES:
+        Multiplier: 70
+        Prerequisites: betterplanes
+        Queue: Aircraft, Helicopter
+    ProductionTimeMultiplier@BETTERPLANES:
+        Multiplier: 80
+        Prerequisites: betterplanes
+        Queue: Aircraft, Helicopter
+        
 
 ^Helicopter:
 	Inherits: ^Plane

--- a/mods/radiv/rules/infantry.yaml
+++ b/mods/radiv/rules/infantry.yaml
@@ -165,12 +165,14 @@ Brute:
 		Cost: 400
 	Tooltip:
 		Name: Brute
+    Armor:
+        Type: Light
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 20000
+		HP: 25000
 	Mobile:
-		Speed: 70
+		Speed: 80
 		AlwaysTurnInPlace: true
 		Locomotor: foot
 	RevealsShroud:
@@ -436,7 +438,7 @@ Officer:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 12000
+		HP: 18000
 	Armament@PRIMARY:
 		Weapon: OfficerRifle
         RequiresCondition: !rank-elite && !rank-elite4
@@ -1420,7 +1422,7 @@ Bombie:
 	Health:
 		HP: 4000
 	Mobile:
-		Speed: 72
+		Speed: 85
 	Explodes:
 		Weapon: BombieExplode   
         EmptyWeapon: BombieExplode

--- a/mods/radiv/rules/player.yaml
+++ b/mods/radiv/rules/player.yaml
@@ -19,6 +19,20 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: True
+        Factions: england, france, germany, russia, ukraine, techno, support, armored, airforce, navy, bio
+    ClassicProductionQueue@Building-Command:
+		Type: Building
+		DisplayOrder: 0
+		LowPowerModifier: 300
+		ReadyAudio: ConstructionComplete
+		BlockedAudio: NoBuild
+		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
+		SpeedUp: True
+        Factions: command
+        BuildTimeSpeedReduction: 90, 75, 65, 55, 45, 40, 35, 30
 	ClassicProductionQueue@Defense:
 		Type: Defense
 		DisplayOrder: 1
@@ -30,6 +44,20 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: True
+        Factions: england, france, germany, russia, ukraine, techno, support, armored, airforce, navy, bio
+    ClassicProductionQueue@Defense-Command:
+		Type: Defense
+		DisplayOrder: 1
+		LowPowerModifier: 300
+		ReadyAudio: ConstructionComplete
+		BlockedAudio: NoBuild
+		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
+		SpeedUp: True
+        Factions: command
+        BuildTimeSpeedReduction: 90, 75, 65, 55, 45, 40, 35, 30
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
 		DisplayOrder: 3
@@ -42,6 +70,20 @@ Player:
 		CancelledAudio: Cancelled
 		SpeedUp: True
 		BuildTimeSpeedReduction: 100, 75, 60, 50
+        Factions: england, france, germany, russia, ukraine, command, techno, support, airforce, navy, bio
+    ClassicProductionQueue@Vehicle-Armored:
+		Type: Vehicle
+		DisplayOrder: 3
+		LowPowerModifier: 300
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
+		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
+		SpeedUp: True
+		BuildTimeSpeedReduction: 90, 70, 55, 45, 35, 30
+        Factions: armored
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		DisplayOrder: 2
@@ -53,6 +95,20 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: True
+        Factions: england, france, germany, russia, ukraine, command, techno, armored, airforce, navy, bio
+    ClassicProductionQueue@Infantry-Support:
+		Type: Infantry
+		DisplayOrder: 2
+		LowPowerModifier: 300
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
+		LimitedAudio: BuildingInProgress
+		QueuedAudio: Training
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
+		SpeedUp: True
+        BuildTimeSpeedReduction: 90, 75, 65, 55, 45, 40, 35, 30
+        Factions: support
 	ClassicProductionQueue@Ship:
 		Type: Ship
 		DisplayOrder: 5
@@ -64,6 +120,20 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: True
+        Factions: england, france, germany, russia, ukraine, command, techno, support, armored, airforce, bio
+    ClassicProductionQueue@Ship-Navy:
+		Type: Ship
+		DisplayOrder: 5
+		LowPowerModifier: 300
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
+		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
+		SpeedUp: True
+        Factions: navy
+        BuildTimeSpeedReduction: 90, 75, 65, 55, 45, 40, 35, 30
 	ClassicProductionQueue@Aircraft:
 		Type: Aircraft
 		DisplayOrder: 4
@@ -75,6 +145,20 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: True
+        Factions: england, france, germany, russia, ukraine, command, techno, support, armored, navy, bio
+    ClassicProductionQueue@Aircraft-Airforce:
+		Type: Aircraft
+		DisplayOrder: 4
+		LowPowerModifier: 300
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
+		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
+		SpeedUp: True
+        Factions: airforce
+        BuildTimeSpeedReduction: 90, 75, 65, 55, 45, 40, 35, 30, 25
 	PlaceBuilding:
 		NewOptionsNotification: NewOptions
 		CannotPlaceNotification: BuildingCannotPlaceAudio

--- a/mods/radiv/rules/structures.yaml
+++ b/mods/radiv/rules/structures.yaml
@@ -751,14 +751,14 @@ CommTower:
 		Prerequisites: dome, ~techlevel.medium, ~structures.command
 		Description: Provides a large radius of vision to allies
     Valued:
-        Cost: 500
+        Cost: 600
     Power:
         Amount: -40
 	Building:
 		Footprint: x
 		Dimensions: 1,1
 	RevealsShroud:
-		Range: 10c0
+		Range: 12c0
 		RevealGeneratedShroud: False
         RequiresCondition: !disabled  && !empdisable
 	RevealsShroud@Offline:
@@ -828,11 +828,11 @@ Headquarters:
 	ProvidesPrerequisite@buildingname:
     GrantExternalConditionPower@HQCHARGE:
         Condition: hqcharge
-        Duration: 500
+        Duration: 375
         ChargeInterval: 2250
         PauseOnCondition: disabled || empdisable
 		Description: Charge!
-		LongDesc: Infantry, vehicles, & ships charge into battle.\n  150% attack damage\n  150% move speed\n  Cost 50% of health\n  Lasts 20s
+		LongDesc: Infantry, vehicles, & ships charge into battle.\n  175% attack damage\n  175% move speed\n Lasts 15s
         SelectTargetSpeechNotification: SelectTarget
         Dimensions: 4, 4
         Footprint: xxxx xxxx xxxx xxxx
@@ -842,11 +842,11 @@ Headquarters:
         SupportPowerPaletteOrder: 1000
     GrantExternalConditionPower@HQENTRENCH:
         Condition: hqentrench
-        Duration: 1125
+        Duration: 750
         ChargeInterval: 2250
         PauseOnCondition: disabled || empdisable
 		Description: Entrench
-		LongDesc: Infantry dig in to hold the line.\n  Take 50% damage\n  Cannot move\n  Lasts 45s
+		LongDesc: Infantry dig in to hold the line.\n  Take 30% damage\n  Lasts 30s
         SelectTargetSpeechNotification: SelectTarget
         Dimensions: 4, 4
         Footprint: xxxx xxxx xxxx xxxx
@@ -856,11 +856,11 @@ Headquarters:
         SupportPowerPaletteOrder: 1100
     GrantExternalConditionPower@HQRETREAT:
         Condition: hqretreat
-        Duration: 375
+        Duration: 175
         ChargeInterval: 1500
         PauseOnCondition: disabled || empdisable
 		Description: Retreat!
-		LongDesc: Infantry, vehicles, & ships flee from battle.\n  200% move speed\n  0% attack damage\n  Lasts 15s
+		LongDesc: Infantry, vehicles, & ships flee from battle.\n  250% move speed\n  0% attack damage\n  Lasts 7s
         SelectTargetSpeechNotification: SelectTarget
         Dimensions: 5, 5
         Footprint: xxxxx xxxxx xxxxx xxxxx xxxxx
@@ -870,11 +870,11 @@ Headquarters:
         SupportPowerPaletteOrder: 1200
     GrantExternalConditionPower@HQSUICIDE:
         Condition: hqsuicide
-        Duration: 255
+        Duration: 380
         ChargeInterval: 3000
         PauseOnCondition: disabled || empdisable
 		Description: Suicide Mission
-		LongDesc: When there's no other hope.\nTargets infantry, vehicles, & ships.\n  200% attack damage\n  200% attack speed\n  150% move speed\n  Take 50% damage\n  Die in 10s
+		LongDesc: When there's no other hope.\nTargets infantry, vehicles, & ships.\n  300% attack damage\n  200% attack speed\n  200% move speed\n  Take 50% damage\n  Die in 15s
         SelectTargetSpeechNotification: SelectTarget
         Dimensions: 3, 3
         Footprint: xxx xxx xxx
@@ -1792,6 +1792,9 @@ FACT:
     ProvidesPrerequisite@FASTBUILD:
         Factions: command
         Prerequisite: fastbuild
+    ProvidesPrerequisite@BETTERPLANES:
+        Factions: airforce
+        Prerequisite: betterplanes
 	Health:
 		HP: 150000
 	Armor:
@@ -2680,6 +2683,27 @@ AFLD.Airforce:
 		StartRepairingNotification: Repairing
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
+	AirstrikePower@spyplane:
+		OrderName: SovietSpyPlane
+		Prerequisites: aircraft.soviet-airforce
+		Icon: spyplane
+		ChargeInterval: 1500
+		Description: Spy Plane
+		LongDesc: Reveals an area of the map.
+		SelectTargetSpeechNotification: SelectTarget
+		EndChargeSpeechNotification: SpyPlaneReady
+		CameraActor: camera.spyplane
+		CameraRemoveDelay: 150
+		UnitType: u2
+		QuantizedFacings: 8
+		DisplayBeacon: true
+		BeaconPoster: camicon
+		ArrowSequence: arrow
+		ClockSequence: clock
+		CircleSequence: circles
+		UseDirectionalTarget: True
+		DirectionArrowAnimation: paradirection
+		SupportPowerPaletteOrder: 60
 
 POWR:
 	Inherits: ^Building
@@ -3003,7 +3027,7 @@ BARR:
 		RequiresCondition: !being-captured
 		SpawnOffset: -725,640,0
 		ExitCell: 0,2
-		ProductionTypes: Soldier, Infantry
+		ProductionTypes: Soldier, Infantry, Infantry-Support
 	Production:
 		Produces: Infantry, Soldier
 	GrantExternalConditionToProduced:
@@ -3294,7 +3318,7 @@ TENT:
 		ExitCell: 0,2
 		ProductionTypes: Soldier, Infantry
 	Production:
-		Produces: Infantry, Soldier
+		Produces: Infantry, Soldier, Infantry-Support
 	GrantExternalConditionToProduced:
 		Condition: produced
 	ProductionBar:

--- a/mods/radiv/rules/vehicles.yaml
+++ b/mods/radiv/rules/vehicles.yaml
@@ -648,7 +648,7 @@ BGGY:
 		Prerequisites: ~vehicles.support, ~techlevel.low
 		Description: Fast buggy that fires rockets.\nAnti-Tank and Anti-Air.
 	Valued:
-		Cost: 800
+		Cost: 650
 	Tooltip:
 		Name: Rocket Buggy
 	UpdatesPlayerStatistics:
@@ -1099,7 +1099,7 @@ FTNK:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
-	Armament:
+	Armament@PRIMARY:
 		Weapon: TankFlame
 		FireDelay: 8
     AttackFrontal:

--- a/mods/radiv/weapons/other.yaml
+++ b/mods/radiv/weapons/other.yaml
@@ -60,16 +60,16 @@ Flamer:
         
 TankFlame:
 	Inherits: ^FireWeapon
-	ReloadDelay: 75
+	ReloadDelay: 50
     Range: 7c0
-	Burst: 50
+	Burst: 80
 	BurstDelays: 2
 	Projectile: Bullet
 		Speed: 170
 		TrailImage: fb4
 		Image: fb3
 		LaunchAngle: 62
-		Inaccuracy: 1000
+		Inaccuracy: 500
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 1000


### PR DESCRIPTION
- Increased comm tower vision by 2 blocks and cost by $100
- Increased Headquarter Charge ability from 150% speed & damage to 175%. Removed 50% health penalty. Lasts 15s instead of 20s
- Headquarter entrench ability now blocks 70% of damage vs 50% and only slows troops to 50% speed vs 5%. Lasts 30s instead of 45s
- Headquarter Retreat ability increases speed by 250% vs 200%. Lasts 7s instead of 15s
- Headquarter Suicide ability increases attack by 300% instead of 200% and speed by 200% instead of 150%. Lasts 15s instead of 10s
Slightly increased Brute speed and gave them light armor (vs none). Increased their health by 25%
- Increased officer bonuses in damage reduction, firepower, and reduced cooldown for health regeneration at veteran levels.
- Increased officer health 50%
- Increased Bombie speed by about 20%
- Cash dude can no longer be crushed
- Flame tanks have increased burst amount and decreased reload times
- Rocket buggies cost $650 instead of $800
- Factions can reduce build time for units by 70% (vs 50%) for their primary unit type (Support - Infantry, Armored - Tanks, Airforce - Planes, Navy - Ships, Command - Buildings/Defenses, Tech - None)
- Gave Airforce general plane building bonuses (like command with buildings). Planes cost 30% less, build 20% faster, and reload twice as fast.
- Doubled Bombers ammo