### PR TITLE
Geneva Bug Fixes

### DIFF
--- a/mods/radiv/rules/defaults.yaml
+++ b/mods/radiv/rules/defaults.yaml
@@ -635,6 +635,14 @@
     SpeedMultiplier@HQCHARGE:
         Modifier: 175
         RequiresCondition: hqcharge
+	WithDecoration@HQCHARGE:
+		Image: pips
+		Sequence: pip-charge
+		Position: TopRight
+		Margin: 17, 4
+		RequiresCondition:hqcharge
+		BlinkInterval: 5
+		BlinkPattern: Off, On
     ExternalCondition@HQRETREAT:
         Condition: hqretreat
 	TimedConditionBar@HQRETREAT:
@@ -645,6 +653,14 @@
     SpeedMultiplier@HQRETREAT:
         Modifier: 250
         RequiresCondition: hqretreat
+	WithDecoration@HQRETREAT:
+		Image: pips
+		Sequence: pip-retreat
+		Position: TopRight
+		Margin: 17, 4
+		RequiresCondition:hqretreat
+		BlinkInterval: 5
+		BlinkPattern: Off, On
     ExternalCondition@HQSUICIDE:
         Condition: hqsuicide
 	TimedConditionBar@HQSUICIDE:
@@ -665,6 +681,14 @@
         Delay: 375
         DamageTypes: DefaultDeath
         RequiresCondition: hqsuicide
+	WithDecoration@HQSUICIDE:
+		Image: pips
+		Sequence: pip-suicide
+		Position: TopRight
+		Margin: 17, 4
+		RequiresCondition:hqsuicide
+		BlinkInterval: 5
+		BlinkPattern: Off, On
 
 ^TrackedVehicle:
 	Inherits: ^Vehicle
@@ -1008,6 +1032,14 @@
     SpeedMultiplier@HQCHARGE:
         Modifier: 150
         RequiresCondition: hqcharge
+	WithDecoration@HQCHARGE:
+		Image: pips
+		Sequence: pip-charge
+		Position: TopRight
+		Margin: 17, 4
+		RequiresCondition:hqcharge
+		BlinkInterval: 5
+		BlinkPattern: Off, On
     ExternalCondition@HQRETREAT:
         Condition: hqretreat
 	TimedConditionBar@HQRETREAT:
@@ -1018,6 +1050,14 @@
     SpeedMultiplier@HQRETREAT:
         Modifier: 250
         RequiresCondition: hqretreat
+	WithDecoration@HQRETREAT:
+		Image: pips
+		Sequence: pip-retreat
+		Position: TopRight
+		Margin: 17, 4
+		RequiresCondition:hqretreat
+		BlinkInterval: 5
+		BlinkPattern: Off, On
     ExternalCondition@HQSUICIDE:
         Condition: hqsuicide
 	TimedConditionBar@HQSUICIDE:
@@ -1038,6 +1078,14 @@
         Delay: 375
         DamageTypes: DefaultDeath
         RequiresCondition: hqsuicide
+	WithDecoration@HQSUICIDE:
+		Image: pips
+		Sequence: pip-suicide
+		Position: TopRight
+		Margin: 17, 4
+		RequiresCondition:hqsuicide
+		BlinkInterval: 5
+		BlinkPattern: Off, On
 
 ^NeutralPlane:
 	Inherits@1: ^ExistsInWorld

--- a/mods/radiv/rules/structures.yaml
+++ b/mods/radiv/rules/structures.yaml
@@ -443,8 +443,8 @@ IRON:
 		Queue: Defense
 		BuildPaletteOrder: 130
 		Prerequisites: techcenter, ~structures.soviet-armored, ~techlevel.unrestricted
-		BuildLimit: 1
-		Description: Makes a group of units invulnerable\nfor a short time.\nRequires power to operate.\nMaximum 1 can be built.\n  Special Ability: Invulnerability
+		Description: Makes a group of units invulnerable\nfor a short time.\nRequires power to operate.\n  Special Ability: Invulnerability
+        BuildLimit: 10
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -2944,9 +2944,9 @@ NUK2:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false
     Explodes:
-		Weapon: MiniNuke
-		EmptyWeapon: MiniNuke
-		DamageSource: Killer
+		Weapon: FriendlyNuke
+		EmptyWeapon: FriendlyNuke
+		DamageSource: Self
     GrantConditionOnPrerequisite@TECHNO:
         Condition: techmoney
         Prerequisites: techmoney


### PR DESCRIPTION
- Allowed Multiple Iron Domes to be built for multiple Iron Walls (Still only one iron curtain ability)
- HQ Command Pips now appear on vehicles and ships as well.
- Nuclear power plants only hurt allies when blown up